### PR TITLE
day2の実施

### DIFF
--- a/daily/day2.py
+++ b/daily/day2.py
@@ -32,9 +32,10 @@ def manhattan_dist(coord1, coord2):
 
     """
     # pass
-    # dist = [abs(c1-c2) for c1, c2 in zip(coord1, coord2)]
-    # l1 = sum(dist)
-    l1 = sum([abs(c1-c2) for c1, c2 in zip(coord1, coord2)])
+    # dist = [abs(c1-c2) for c1, c2 in zip(coord1, coord2)]     #v1
+    # l1 = sum(dist)                                            #v1
+    # l1 = sum([abs(c1-c2) for c1, c2 in zip(coord1, coord2)])  #v2
+    l1 = sum( abs(c1-c2) for c1, c2 in zip(coord1, coord2) )    #v3
 
     return l1
 

--- a/daily/day2.py
+++ b/daily/day2.py
@@ -31,9 +31,11 @@ def manhattan_dist(coord1, coord2):
     l1 : 数値
 
     """
-    pass
+    # pass
+    dist = [abs(c1-c2) for c1, c2 in zip(coord1, coord2)]
+    l1 = sum(dist)
 
-    # return l1
+    return l1
 
 
 if __name__ == "__main__":

--- a/daily/day2.py
+++ b/daily/day2.py
@@ -32,8 +32,9 @@ def manhattan_dist(coord1, coord2):
 
     """
     # pass
-    dist = [abs(c1-c2) for c1, c2 in zip(coord1, coord2)]
-    l1 = sum(dist)
+    # dist = [abs(c1-c2) for c1, c2 in zip(coord1, coord2)]
+    # l1 = sum(dist)
+    l1 = sum([abs(c1-c2) for c1, c2 in zip(coord1, coord2)])
 
     return l1
 


### PR DESCRIPTION
## 種類

- [x] 問題の解答
- [ ] 問題の作成
- [ ] 問題の変更
- [ ] バグの修正

## 要約

- 要点1
引数としてmanhattan_dist()に与えられる二つのリストは、それぞれ0番目がx座標,1番目がy座標を表す。したがって、x座標の距離、y座標の距離をそれぞれ出す際に0番目同士,1番目同士の和を取るためにzip関数を用いた。
- 要点2
単純な座標同士の差では負になってしまうため、abs()関数を用いて絶対値を取った。abs(x)は,xの絶対値を返す関数である。
- 要点3
それぞれの座標の距離がdistというlistに保存されたのち、それを和する必要があるため、sum関数を用いた。これは引数で与えられた反復可能オブジェクトの総和を求める関数である。
